### PR TITLE
chore: skip build for darwin

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "description": "NodeJS native module written in Rust and Typescript to interact with Pipewire",
   "main": "build/index.js",
   "scripts": {
-    "build": "tsc && cargo-cp-artifact -nc build/index.node -- cargo build --message-format=json-render-diagnostics",
+    "build": "tsc && npm run check-platform; [ $? -ne 0 ] || cargo-cp-artifact -nc build/index.node -- cargo build --message-format=json-render-diagnostics",
     "build-cross": "tsc && cross build --target $TARGET && cp target/$TARGET/release/libnode_pipewire.so build/index.node",
     "build-cross:release": "tsc && cross build --target $TARGET --release && cp target/$TARGET/release/libnode_pipewire.so build/index.node",
     "build-debug": "npm run build --",
     "build-release": "npm run build -- --release",
+    "check-platform": "[ $(uname) != 'Darwin' ] || (echo 'Platform not supported. Skipping build.'; exit 1)",
     "install": "node-pre-gyp install --fallback-to-build=false || npm run build-release",
     "test": "cargo test",
     "package": "node-pre-gyp package",


### PR DESCRIPTION
Hi, I’m using `node-pipewire` in a monorepo. I’d like to run just the frontend or even stub the library to run the server on macOS, but that’s currently not possible. If `node-pipewire` is listed as a dependency, `npm install` fails.

Not sure if this is the best approach, but it works -- I’ve tested it on both Linux and macOS.